### PR TITLE
Fields cause and message in JsonSyntaxException were made public. 

### DIFF
--- a/modules/swift-commons/SwiftCommons/Sources/Data/Model/ParcelableModel.swift
+++ b/modules/swift-commons/SwiftCommons/Sources/Data/Model/ParcelableModel.swift
@@ -28,7 +28,7 @@ public class ParcelableModel: Parcelable, Mappable, Hashable,
         Try {
 
             // Deserialize object
-            let result = self.tryMapping() {
+            let _ = self.tryMapping() {
                 Mapper().map(params, toObject: self)
             }
 

--- a/modules/swift-commons/SwiftCommons/Sources/Helper/JsonSyntaxException.swift
+++ b/modules/swift-commons/SwiftCommons/Sources/Helper/JsonSyntaxException.swift
@@ -40,9 +40,9 @@ public class JsonSyntaxException: ErrorType
 
 // MARK: - Properties
 
-    let message: String?
+    public let message: String?
 
-    let cause: NSException?
+    public let cause: NSException?
 
 }
 


### PR DESCRIPTION
Replace "result" with wildcard in ParcelableModel